### PR TITLE
Fix missing shutdown function in type declarations

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ declare function nodeHtmlToImage(options: NodeHtmlToImageConstructorOptions): No
 
 export interface NodeHtmlToImageInstance {
   render(options: NodeHtmlToImageOptions): Promise<string | Buffer | (string | Buffer)[]>;
-  async shutdown(): Promise<void>;
+  shutdown(): Promise<void>;
 }
 
 export default nodeHtmlToImage;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,6 +10,7 @@ declare function nodeHtmlToImage(options: NodeHtmlToImageConstructorOptions): No
 
 export interface NodeHtmlToImageInstance {
   render(options: NodeHtmlToImageOptions): Promise<string | Buffer | (string | Buffer)[]>;
+  async shutdown(): Promise<void>;
 }
 
 export default nodeHtmlToImage;


### PR DESCRIPTION
Really quick PR - I noticed that the instance's `shutdown()` function was missing from the type declarations.